### PR TITLE
Add basic setup files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# RIS-VEC-MARL
+
+This repository contains simulation code for multi-agent reinforcement learning experiments.
+
+## Setup
+
+Before running any training or testing scripts, install the required Python packages:
+
+```bash
+bash setup.sh
+```
+
+The script installs dependencies listed in `requirements.txt` using `pip`.
+
+## Usage
+
+After setup, run the desired training or testing scripts located in `Simulation-MARL-BCD` or `Simulation-SARL`.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+scipy
+matplotlib
+torch

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- add `requirements.txt` listing main Python packages
- add `setup.sh` to install dependencies
- document installation and usage steps in `README`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `bash setup.sh` *(partially runs but heavy downloads, manually interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6860da8c621c832e8b5918f53aaccfd7